### PR TITLE
Use `fti.Title()` that is a i18n `Message` instance to manage settings `portal_types` vocabulary.  Also sort vocabulary by term title.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@ Changelog
 0.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Use `fti.Title()` that is a i18n `Message` instance to manage settings
+  `portal_types` vocabulary.  Also sort vocabulary by term title.
+  [gbastien]
 
 0.3 (2023-11-27)
 ----------------

--- a/src/collective/behavior/internalnumber/browser/settings.py
+++ b/src/collective/behavior/internalnumber/browser/settings.py
@@ -5,6 +5,7 @@ from collective.behavior.internalnumber import TYPE_CONFIG
 from collective.behavior.talcondition.utils import _evaluateExpression
 from collective.z3cform.datagridfield.datagridfield import DataGridFieldFactory
 from collective.z3cform.datagridfield.registry import DictRow
+from operator import attrgetter
 from plone import api
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
 from plone.app.registry.browser.controlpanel import RegistryEditForm
@@ -15,8 +16,7 @@ from Products.CMFPlone.utils import base_hasattr
 from z3c.form import form
 from zope import schema
 from zope.component import getAllUtilitiesRegisteredFor
-from zope.component import getUtility
-from zope.i18n.interfaces import ITranslationDomain
+from zope.i18n import translate
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.schema.interfaces import IVocabularyFactory
@@ -187,7 +187,10 @@ class DxPortalTypesVocabulary(object):
         ftis = getAllUtilitiesRegisteredFor(IDexterityFTI)
         portal = api.portal.get()
         for fti in ftis:
-            translation_domain = getUtility(ITranslationDomain, fti.i18n_domain)
-            terms.append(SimpleTerm(fti.id, fti.id, translation_domain.translate(
-                fti.title, context=portal.REQUEST)))
+            terms.append(
+                SimpleTerm(
+                    fti.id,
+                    fti.id,
+                    translate(fti.Title(), context=portal.REQUEST)))
+        terms = sorted(terms, key=attrgetter('title'))
         return SimpleVocabulary(terms)

--- a/src/collective/behavior/internalnumber/browser/settings.py
+++ b/src/collective/behavior/internalnumber/browser/settings.py
@@ -188,9 +188,6 @@ class DxPortalTypesVocabulary(object):
         portal = api.portal.get()
         for fti in ftis:
             terms.append(
-                SimpleTerm(
-                    fti.id,
-                    fti.id,
-                    translate(fti.Title(), context=portal.REQUEST)))
+                SimpleTerm(fti.id, fti.id, translate(fti.Title(), context=portal.REQUEST)))
         terms = sorted(terms, key=attrgetter('title'))
         return SimpleVocabulary(terms)

--- a/src/collective/behavior/internalnumber/tests/test_settings.py
+++ b/src/collective/behavior/internalnumber/tests/test_settings.py
@@ -9,7 +9,6 @@ from collective.behavior.internalnumber.browser.settings import get_settings
 from collective.behavior.internalnumber.browser.settings import increment_nb_for
 from collective.behavior.internalnumber.browser.settings import set_settings
 from collective.behavior.internalnumber.testing import COLLECTIVE_BEHAVIOR_INTERNALNUMBER_INTEGRATION_TESTING  # noqa
-from operator import itemgetter
 from plone import api
 
 import unittest
@@ -41,8 +40,7 @@ class TestSettings(unittest.TestCase):
         self.assertDictEqual(get_pt_settings('testtype'), {u'u': False, u'nb': 1, 'expr': u'number'})
 
     def test_DxPortalTypesVocabulary(self):
-        voc_inst = DxPortalTypesVocabulary()
-        voc_list = sorted([(t.value, t.title) for t in voc_inst(self.portal)], key=itemgetter(1))
+        voc_list = [(t.value, t.title) for t in DxPortalTypesVocabulary()(self.portal)]
         if PLONE_VERSION == '4.3':
             res = [('glo_bal', u'Global configuration'), ('testtype', u'Test type')]
         elif PLONE_VERSION == '5.2':


### PR DESCRIPTION
See #PM-4061